### PR TITLE
Create dedicated agent detail pages with HITL tooling

### DIFF
--- a/agent.html
+++ b/agent.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Global AI Agent Command Center · Agent Detail</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="agent-page-body">
+    <header class="agent-topbar">
+      <a class="topbar-brand" href="index.html">
+        <span class="brand-acronym">GAACC</span>
+        <div class="brand-copy">
+          <strong>Global AI Agent Command Center</strong>
+          <span>Agent operations &amp; governance</span>
+        </div>
+      </a>
+      <a class="ghost-btn back-link" href="index.html">← Back to mission control</a>
+    </header>
+    <main id="agent-root" class="agent-main" aria-live="polite"></main>
+    <script type="module" src="agent.js"></script>
+  </body>
+</html>

--- a/agent.js
+++ b/agent.js
@@ -1,0 +1,492 @@
+import { agents } from "./data.js";
+import { statusToColor, guardrailCopy } from "./utils.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const root = document.getElementById("agent-root");
+  const params = new URLSearchParams(window.location.search);
+  const agentId = params.get("id");
+  const agent = agents.find((item) => item.id === agentId);
+
+  if (!agent) {
+    renderMissingAgent(root, agentId);
+    return;
+  }
+
+  const state = {
+    queue: agent.hitl.queue.map((item) => ({ ...item })),
+    decisions: [...agent.hitl.decisionLog],
+    actionCompletion: agent.insights.actions.map(() => false),
+  };
+
+  const rerender = () => renderAgentView(root, agent, state, rerender);
+  rerender();
+});
+
+function renderMissingAgent(root, agentId) {
+  root.innerHTML = "";
+  const card = document.createElement("section");
+  card.className = "detail-card agent-missing";
+  card.innerHTML = `
+    <h2>Agent not found</h2>
+    <p class="muted">We couldn't locate an agent with the ID <strong>${agentId ?? "unknown"}</strong>.</p>
+    <div class="hero-buttons">
+      <a class="primary-btn" href="index.html">Return to mission control</a>
+    </div>
+  `;
+  root.appendChild(card);
+}
+
+function renderAgentView(root, agent, state, rerender) {
+  root.innerHTML = "";
+  root.appendChild(buildHero(agent));
+
+  const layout = document.createElement("div");
+  layout.className = "agent-detail-grid";
+
+  const primary = document.createElement("section");
+  primary.className = "agent-detail-primary";
+  primary.appendChild(buildHitlSection(agent, state, rerender));
+  primary.appendChild(buildPerformanceSection(agent));
+
+  const secondary = document.createElement("aside");
+  secondary.className = "agent-detail-secondary";
+  secondary.appendChild(buildInsightsSection(agent, state, rerender));
+  secondary.appendChild(buildGuardrailsCard(agent));
+  secondary.appendChild(buildDependenciesCard(agent));
+  secondary.appendChild(buildPlaybooksCard(agent));
+  secondary.appendChild(buildActivityCard(agent));
+
+  layout.appendChild(primary);
+  layout.appendChild(secondary);
+  root.appendChild(layout);
+}
+
+function buildHero(agent) {
+  const hero = document.createElement("section");
+  hero.className = "detail-card agent-hero-card";
+  hero.innerHTML = `
+    <div class="agent-hero-header">
+      <div>
+        <span class="muted">${agent.id}</span>
+        <h1>${agent.name}</h1>
+        <div class="agent-hero-meta">
+          <span>${agent.businessUnit}</span>
+          <span>${agent.owner}</span>
+          <span class="risk-chip risk-${agent.riskLevel}">Risk: ${agent.riskLevel.toUpperCase()}</span>
+        </div>
+      </div>
+      <div class="agent-hero-status">
+        <span class="status-pill ${statusToColor(agent.status)}">${agent.status.toUpperCase()}</span>
+        <div class="hero-buttons">
+          <button class="primary-btn" type="button">Launch Playbook</button>
+          <button class="ghost-btn" type="button">Pause Agent</button>
+          <button class="ghost-btn" type="button">Escalate</button>
+        </div>
+      </div>
+    </div>
+    <div class="agent-hero-foot">
+      ${[
+        { label: "Success Rate", value: `${Math.round(agent.successRate * 100)}%` },
+        { label: "Automation", value: `${Math.round(agent.automationRate * 100)}%` },
+        { label: "Avg Latency", value: `${agent.avgLatency}s` },
+        { label: "Hours Saved", value: agent.hoursSaved.toLocaleString() },
+        { label: "Last Incident", value: agent.lastIncident },
+      ]
+        .map(
+          (metric) => `
+            <div>
+              <span>${metric.label}</span>
+              <strong>${metric.value}</strong>
+            </div>
+          `
+        )
+        .join("")}
+    </div>
+  `;
+  return hero;
+}
+
+function buildHitlSection(agent, state, rerender) {
+  const pending = state.queue.filter((item) => item.status !== "completed").length;
+  const section = document.createElement("section");
+  section.className = "detail-card hitl-console";
+  section.innerHTML = `
+    <div class="section-header">
+      <h3>Human-in-the-Loop Console</h3>
+      <span class="status-pill ${pending ? "orange" : "green"}">${pending} open</span>
+    </div>
+    <p class="muted">Coordinate manual approvals, escalations, and annotations for this agent.</p>
+    <div class="hitl-queue" role="list"></div>
+    <form class="hitl-note" aria-label="Log human decision">
+      <label for="hitl-note-field">
+        <span>Add operator note</span>
+      </label>
+      <textarea id="hitl-note-field" rows="3" maxlength="280" placeholder="Document decisions, context, or follow-up actions"></textarea>
+      <div class="hitl-note-footer">
+        <span class="muted char-count">0 / 280</span>
+        <button class="primary-btn" type="submit">Log decision</button>
+      </div>
+    </form>
+    <div class="hitl-log">
+      <h4>Decision log</h4>
+      <ul class="timeline"></ul>
+    </div>
+  `;
+
+  const queueContainer = section.querySelector(".hitl-queue");
+  if (!state.queue.length) {
+    queueContainer.innerHTML = `<p class="muted">No manual interventions required.</p>`;
+  } else {
+    state.queue.forEach((item, index) => {
+      queueContainer.appendChild(buildHitlCard(item, index, state, rerender));
+    });
+  }
+
+  const logList = section.querySelector(".timeline");
+  if (!state.decisions.length) {
+    const empty = document.createElement("li");
+    empty.className = "timeline-item";
+    empty.textContent = "No human decisions recorded yet.";
+    logList.appendChild(empty);
+  } else {
+    state.decisions.forEach((entry) => {
+      const item = document.createElement("li");
+      item.className = "timeline-item";
+      item.innerHTML = entry;
+      logList.appendChild(item);
+    });
+  }
+
+  const noteForm = section.querySelector(".hitl-note");
+  const textarea = noteForm.querySelector("textarea");
+  const counter = noteForm.querySelector(".char-count");
+  textarea.addEventListener("input", () => {
+    const length = textarea.value.length;
+    counter.textContent = `${length} / 280`;
+  });
+
+  noteForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const value = textarea.value.trim();
+    if (!value) return;
+    appendDecision(state, `Operator note: ${value}`);
+    textarea.value = "";
+    counter.textContent = "0 / 280";
+    rerender();
+  });
+
+  return section;
+}
+
+function buildHitlCard(item, index, state, rerender) {
+  const card = document.createElement("article");
+  card.className = `hitl-item status-${item.status}`;
+  card.innerHTML = `
+    <header>
+      <div>
+        <strong>${item.title}</strong>
+        <p class="muted">${item.description}</p>
+      </div>
+      <span class="status-pill ${statusToColor(item.status)}">${formatStatusLabel(item.status)}</span>
+    </header>
+    <footer>
+      <div class="hitl-meta">
+        <span>SLA ${item.sla}</span>
+        <span>${item.channel}</span>
+        <span>${item.assignee}</span>
+      </div>
+      <div class="hitl-actions">
+        <button class="ghost-btn" type="button" data-action="start">Start review</button>
+        <button class="primary-btn" type="button" data-action="resolve">Mark resolved</button>
+        <button class="ghost-btn" type="button" data-action="escalate">Escalate</button>
+      </div>
+    </footer>
+  `;
+
+  const actions = card.querySelectorAll("button[data-action]");
+  actions.forEach((button) => {
+    button.disabled = item.status === "completed";
+  });
+
+  const startBtn = card.querySelector('button[data-action="start"]');
+  const resolveBtn = card.querySelector('button[data-action="resolve"]');
+  const escalateBtn = card.querySelector('button[data-action="escalate"]');
+
+  if (item.status !== "pending") {
+    startBtn.disabled = true;
+  }
+  if (item.status === "escalated") {
+    escalateBtn.disabled = true;
+  }
+
+  startBtn.addEventListener("click", () => {
+    state.queue[index].status = "investigating";
+    appendDecision(state, `${item.id}: reviewer acknowledged via HITL console`);
+    rerender();
+  });
+
+  resolveBtn.addEventListener("click", () => {
+    state.queue[index].status = "completed";
+    appendDecision(state, `${item.id}: resolved and agent unblocked`);
+    rerender();
+  });
+
+  escalateBtn.addEventListener("click", () => {
+    state.queue[index].status = "escalated";
+    appendDecision(state, `${item.id}: escalated to ${item.assignee}`);
+    rerender();
+  });
+
+  return card;
+}
+
+function buildPerformanceSection(agent) {
+  const section = document.createElement("section");
+  section.className = "detail-card performance-card";
+  section.innerHTML = `
+    <div class="section-header">
+      <h3>Performance &amp; Error Intelligence</h3>
+      <span class="status-pill ${statusToColor(agent.status)}">${agent.status.toUpperCase()}</span>
+    </div>
+    <p class="muted">Understand execution quality, hotspots, and recent incidents.</p>
+  `;
+
+  const metricGrid = document.createElement("div");
+  metricGrid.className = "performance-metric-grid";
+  agent.performance.metrics.forEach((metric) => {
+    const item = document.createElement("article");
+    item.innerHTML = `
+      <span>${metric.label}</span>
+      <strong>${metric.value}</strong>
+      <small class="muted">${metric.trend}</small>
+    `;
+    metricGrid.appendChild(item);
+  });
+  section.appendChild(metricGrid);
+
+  const errorWrapper = document.createElement("div");
+  errorWrapper.className = "error-breakdown";
+  const maxCount = Math.max(...agent.performance.errorBreakdown.map((item) => item.count), 1);
+  agent.performance.errorBreakdown.forEach((item) => {
+    const row = document.createElement("div");
+    row.className = "error-row";
+    row.innerHTML = `
+      <div class="error-label">
+        <strong>${item.label}</strong>
+        <small class="muted">${item.change}</small>
+      </div>
+      <div class="error-bar-track">
+        <div class="error-bar-fill" role="progressbar" aria-valuemin="0" aria-valuemax="${maxCount}" aria-valuenow="${item.count}" style="width: ${(item.count / maxCount) * 100}%"></div>
+      </div>
+      <span class="error-count">${item.count}</span>
+    `;
+    errorWrapper.appendChild(row);
+  });
+  section.appendChild(errorWrapper);
+
+  const incidents = document.createElement("div");
+  incidents.className = "timeline incident-timeline";
+  agent.performance.incidents.forEach((incident) => {
+    const item = document.createElement("div");
+    item.className = "timeline-item incident-item";
+    item.innerHTML = `
+      <strong>${incident.timestamp}</strong>
+      <p>${incident.summary}</p>
+      <span class="muted">${incident.resolution}</span>
+    `;
+    incidents.appendChild(item);
+  });
+  section.appendChild(incidents);
+
+  const evalNotes = document.createElement("div");
+  evalNotes.className = "evaluation-notes";
+  const heading = document.createElement("h4");
+  heading.textContent = "Evaluation focus";
+  evalNotes.appendChild(heading);
+  const list = document.createElement("ul");
+  list.className = "note-list";
+  agent.performance.evaluationNotes.forEach((note) => {
+    const li = document.createElement("li");
+    li.textContent = note;
+    list.appendChild(li);
+  });
+  evalNotes.appendChild(list);
+  section.appendChild(evalNotes);
+
+  return section;
+}
+
+function buildInsightsSection(agent, state, rerender) {
+  const section = document.createElement("section");
+  section.className = "detail-card insights-card";
+  section.innerHTML = `
+    <div class="section-header">
+      <h3>Insights &amp; Recommended Actions</h3>
+    </div>
+    <p class="muted">${agent.insights.narrative}</p>
+    <div class="insight-actions"></div>
+    <div class="insight-opportunities">
+      <h4>Opportunities to explore</h4>
+      <div class="badge-grid"></div>
+    </div>
+  `;
+
+  const actionList = section.querySelector(".insight-actions");
+  agent.insights.actions.forEach((action, index) => {
+    const card = document.createElement("article");
+    card.className = "insight-action";
+    const completed = state.actionCompletion[index];
+    card.innerHTML = `
+      <header>
+        <strong>${action.title}</strong>
+        <span class="status-pill ${completed ? "green" : "orange"}">${completed ? "Completed" : action.status}</span>
+      </header>
+      <p>${action.description}</p>
+      <footer>
+        <span>${action.owner}</span>
+        <span>${action.impact}</span>
+        <span>${action.due}</span>
+      </footer>
+      <button class="primary-btn" type="button">${completed ? "Logged" : "Mark complete"}</button>
+    `;
+    const button = card.querySelector("button");
+    if (completed) {
+      button.disabled = true;
+    } else {
+      button.addEventListener("click", () => {
+        state.actionCompletion[index] = true;
+        appendDecision(state, `${action.title} marked complete by operations`);
+        rerender();
+      });
+    }
+    actionList.appendChild(card);
+  });
+
+  const badgeGrid = section.querySelector(".badge-grid");
+  agent.insights.opportunities.forEach((item) => {
+    const badge = document.createElement("span");
+    badge.className = "chip";
+    badge.textContent = `${item.label} • ${item.detail}`;
+    badgeGrid.appendChild(badge);
+  });
+
+  return section;
+}
+
+function buildGuardrailsCard(agent) {
+  const section = document.createElement("section");
+  section.className = "detail-card guardrail-card";
+  section.innerHTML = `
+    <h4>Guardrail health</h4>
+    <div class="policy-grid"></div>
+  `;
+
+  const grid = section.querySelector(".policy-grid");
+  agent.guardrails.forEach((guardrail) => {
+    const card = document.createElement("article");
+    card.className = "policy-card";
+    card.innerHTML = `
+      <header>
+        <strong>${guardrail.name}</strong>
+        <span class="status-pill ${statusToColor(guardrail.status)}">${guardrail.status.toUpperCase()}</span>
+      </header>
+      <p class="muted">${guardrailCopy(guardrail.status)}</p>
+    `;
+    grid.appendChild(card);
+  });
+
+  return section;
+}
+
+function buildDependenciesCard(agent) {
+  const section = document.createElement("section");
+  section.className = "detail-card dependencies-card";
+  section.innerHTML = `
+    <h4>Dependencies</h4>
+    <p class="muted">Keep blast radius in check before making upstream changes.</p>
+    <div class="badge-grid" data-type="tools"></div>
+    <div class="badge-grid" data-type="connectors"></div>
+    <div class="badge-grid" data-type="policies"></div>
+  `;
+
+  const toolGrid = section.querySelector('[data-type="tools"]');
+  agent.dependencies.tools.forEach((tool) => {
+    const chip = document.createElement("span");
+    chip.className = "chip";
+    chip.textContent = `🛠 ${tool}`;
+    toolGrid.appendChild(chip);
+  });
+
+  const connectorGrid = section.querySelector('[data-type="connectors"]');
+  agent.dependencies.connectors.forEach((connector) => {
+    const chip = document.createElement("span");
+    chip.className = "chip";
+    chip.textContent = `🔌 ${connector}`;
+    connectorGrid.appendChild(chip);
+  });
+
+  const policyGrid = section.querySelector('[data-type="policies"]');
+  agent.dependencies.policies.forEach((policy) => {
+    const chip = document.createElement("span");
+    chip.className = "chip";
+    chip.textContent = `🛡 ${policy}`;
+    policyGrid.appendChild(chip);
+  });
+
+  return section;
+}
+
+function buildPlaybooksCard(agent) {
+  const section = document.createElement("section");
+  section.className = "detail-card playbook-card";
+  section.innerHTML = `
+    <h4>Playbooks</h4>
+    <ul class="note-list"></ul>
+  `;
+  const list = section.querySelector(".note-list");
+  agent.hitl.playbooks.forEach((playbook) => {
+    const item = document.createElement("li");
+    item.textContent = playbook;
+    list.appendChild(item);
+  });
+  return section;
+}
+
+function buildActivityCard(agent) {
+  const section = document.createElement("section");
+  section.className = "detail-card activity-card";
+  section.innerHTML = `
+    <h4>Recent activity</h4>
+    <div class="timeline"></div>
+  `;
+  const timeline = section.querySelector(".timeline");
+  agent.recentActivity.forEach((entry) => {
+    const item = document.createElement("div");
+    item.className = "timeline-item";
+    item.textContent = entry;
+    timeline.appendChild(item);
+  });
+  return section;
+}
+
+function appendDecision(state, entry) {
+  const timestamp = formatNow();
+  state.decisions = [`${timestamp} • ${entry}`, ...state.decisions];
+}
+
+function formatNow() {
+  const now = new Date();
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  const dd = String(now.getDate()).padStart(2, "0");
+  const hh = String(now.getHours()).padStart(2, "0");
+  const min = String(now.getMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} ${hh}:${min}`;
+}
+
+function formatStatusLabel(status) {
+  return status
+    .replace(/_/g, " ")
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}

--- a/app.js
+++ b/app.js
@@ -1,331 +1,23 @@
+import {
+  copy,
+  agents,
+  actionQueue,
+  insights,
+  recommendations,
+  policies,
+  experiments,
+} from "./data.js";
+import { statusToColor } from "./utils.js";
+
 const state = {
   module: "inventory",
   perspective: "ops",
-  selectedAgent: null,
-  detailView: "profile",
-  agentPage: false,
   filters: {
     status: "all",
     businessUnit: "all",
     risk: "all",
   },
 };
-
-const copy = {
-  inventory: {
-    title: "Inventory Manager",
-    subtitle: "Real-time view of deployed agents, their state, and health.",
-  },
-  hitl: {
-    title: "Human-in-the-Loop Console",
-    subtitle: "Route escalations, manage approvals, and keep SLAs on track.",
-  },
-  insights: {
-    title: "Outcome Insights",
-    subtitle: "Quantify business impact and surface levers for improvement.",
-  },
-  governance: {
-    title: "Governance & Guardrails",
-    subtitle: "Ensure policies travel with agents and every decision is auditable.",
-  },
-  optimization: {
-    title: "Optimization Lab",
-    subtitle: "Experiment, tune, and control cost-quality tradeoffs at scale.",
-  },
-};
-
-const agents = [
-  {
-    id: "AIOPS-017",
-    name: "Revenue Ops Planner",
-    status: "active",
-    businessUnit: "Go-To-Market",
-    owner: "Ops Automation Guild",
-    successRate: 0.94,
-    automationRate: 0.81,
-    avgLatency: 6.2,
-    hoursSaved: 4820,
-    lastIncident: "12d ago",
-    riskLevel: "medium",
-    adoption: "Global Sales",
-    dependencies: {
-      tools: ["Salesforce", "Tableau", "SAP"],
-      connectors: ["Databricks Lakehouse", "Palantir AIP"],
-      policies: ["SOX Controls", "PII Masking"],
-    },
-    guardrails: [
-      { name: "Financial Data Boundary", status: "green" },
-      { name: "Revenue Forecast Review", status: "orange" },
-    ],
-    recentActivity: [
-      "Generated Q4 revenue coverage plan",
-      "Escalated contract anomaly to finance reviewer",
-      "Rolled back retrieval model after canary drift",
-    ],
-  },
-  {
-    id: "CX-204",
-    name: "Customer Care Orchestrator",
-    status: "active",
-    businessUnit: "Customer Experience",
-    owner: "Support Ops",
-    successRate: 0.89,
-    automationRate: 0.74,
-    avgLatency: 3.8,
-    hoursSaved: 6950,
-    lastIncident: "3d ago",
-    riskLevel: "low",
-    adoption: "Tier 1 & 2 Support",
-    dependencies: {
-      tools: ["Zendesk", "Slack", "ServiceNow"],
-      connectors: ["LangSmith", "Mosaic Gateway"],
-      policies: ["GDPR Privacy Pack", "PCI Redaction"],
-    },
-    guardrails: [
-      { name: "EU Data Residency", status: "green" },
-      { name: "Payment Redaction", status: "green" },
-    ],
-    recentActivity: [
-      "Deflected billing ticket with self-service workflow",
-      "Routed outage escalation to on-call engineer",
-      "Captured CSAT feedback into evaluation dataset",
-    ],
-  },
-  {
-    id: "RISK-88",
-    name: "Third-Party Risk Analyst",
-    status: "paused",
-    businessUnit: "Risk & Compliance",
-    owner: "Enterprise Trust",
-    successRate: 0.76,
-    automationRate: 0.52,
-    avgLatency: 12.5,
-    hoursSaved: 1830,
-    lastIncident: "2h ago",
-    riskLevel: "high",
-    adoption: "Vendor Management",
-    dependencies: {
-      tools: ["GRC Vault", "DocuSign"],
-      connectors: ["AI Gateway", "Policy Engine"],
-      policies: ["AI Act Tier 2", "Vendor Risk Guardrails"],
-    },
-    guardrails: [
-      { name: "Sensitive Document Access", status: "red" },
-      { name: "Dual Control", status: "orange" },
-    ],
-    recentActivity: [
-      "Paused after exceeding false positive threshold",
-      "Requested manual review for procurement contract",
-      "Generated audit evidence pack for Q3",
-    ],
-  },
-  {
-    id: "SUPPLY-61",
-    name: "Supply Chain Navigator",
-    status: "active",
-    businessUnit: "Operations",
-    owner: "Fulfillment PMO",
-    successRate: 0.91,
-    automationRate: 0.68,
-    avgLatency: 8.4,
-    hoursSaved: 3810,
-    lastIncident: "7d ago",
-    riskLevel: "medium",
-    adoption: "Global Logistics",
-    dependencies: {
-      tools: ["SAP IBP", "Snowflake"],
-      connectors: ["Mosaic Gateway", "Vertex Forecast API"],
-      policies: ["Export Control", "Supplier Compliance"],
-    },
-    guardrails: [
-      { name: "Cold Chain Policy", status: "green" },
-      { name: "Supplier Risk", status: "green" },
-    ],
-    recentActivity: [
-      "Predicted port congestion impact for APAC",
-      "Triggered alternate route automation",
-      "Logged scenario to optimization notebook",
-    ],
-  },
-  {
-    id: "HR-142",
-    name: "Talent Mobility Advisor",
-    status: "failed",
-    businessUnit: "People",
-    owner: "HR Innovation",
-    successRate: 0.63,
-    automationRate: 0.41,
-    avgLatency: 5.9,
-    hoursSaved: 940,
-    lastIncident: "12m ago",
-    riskLevel: "medium",
-    adoption: "Corporate HR",
-    dependencies: {
-      tools: ["Workday", "Greenhouse"],
-      connectors: ["AI Gateway", "Employee Graph"],
-      policies: ["PII Safe Handling", "Bias Monitoring"],
-    },
-    guardrails: [
-      { name: "Bias Monitoring", status: "red" },
-      { name: "PII Masking", status: "orange" },
-    ],
-    recentActivity: [
-      "Failed to complete internal transfer recommendation",
-      "Escalated to HRBP for manual approval",
-      "Opened eval notebook for fairness regression",
-    ],
-  },
-];
-
-const actionQueue = [
-  {
-    id: "INC-4450",
-    title: "Procurement Contract Review",
-    summary: "Vendor clause flagged as ambiguous. Needs legal validation before execution.",
-    status: "pending",
-    sla: "02:15",
-    businessUnit: "Risk & Compliance",
-    workflow: "Third-Party Risk Analyst",
-    urgency: "high",
-  },
-  {
-    id: "INC-4412",
-    title: "Customer Refund Escalation",
-    summary: "High value customer requested manual override for refund exception.",
-    status: "pending",
-    sla: "00:42",
-    businessUnit: "Customer Experience",
-    workflow: "Customer Care Orchestrator",
-    urgency: "critical",
-  },
-  {
-    id: "INC-4390",
-    title: "AI Policy Drift",
-    summary: "Policy pack mismatch detected between staging and production gateways.",
-    status: "escalated",
-    sla: "04:20",
-    businessUnit: "Platform",
-    workflow: "Gateway Governance",
-    urgency: "medium",
-  },
-  {
-    id: "INC-4302",
-    title: "Forecast Accuracy Regression",
-    summary: "A/B test variant B regressed cost-to-serve by 6%.",
-    status: "investigating",
-    sla: "08:00",
-    businessUnit: "Operations",
-    workflow: "Supply Chain Navigator",
-    urgency: "medium",
-  },
-  {
-    id: "INC-4220",
-    title: "Successful Automation Review",
-    summary: "Bulk billing adjustments auto-approved with zero escalations for 48h.",
-    status: "completed",
-    sla: "--",
-    businessUnit: "Finance",
-    workflow: "Revenue Ops Planner",
-    urgency: "low",
-  },
-];
-
-const insights = {
-  ops: [
-    { label: "Autonomy Rate", value: "78%", trend: "+6.2% vs last month" },
-    { label: "Average Time Saved", value: "11.4 hrs/task", trend: "+1.8 hrs" },
-    { label: "Escalation MTTR", value: "34 min", trend: "-12 min" },
-    { label: "Coverage", value: "146 agents", trend: "+18 onboarded" },
-  ],
-  exec: [
-    { label: "Hours Returned to Business", value: "38,420", trend: "+4,120 YoY" },
-    { label: "Net Cost Avoidance", value: "$7.9M", trend: "+$900k QoQ" },
-    { label: "CSAT Lift", value: "+9.4 pts", trend: "+1.1 pts" },
-    { label: "Adoption Velocity", value: "21 new teams", trend: "+5 vs target" },
-  ],
-  security: [
-    { label: "Policy Coverage", value: "98.4%", trend: "+0.8%" },
-    { label: "High Risk Agents", value: "4", trend: "-2 vs last week" },
-    { label: "Audit Evidence Packs", value: "27 ready", trend: "GDPR, HIPAA" },
-    { label: "Incident Containment", value: "< 6 min", trend: "SOAR auto-closure" },
-  ],
-};
-
-const recommendations = [
-  {
-    title: "Promote Variant B for Customer Care",
-    impact: "+4.2% FCR / -3% cost",
-    rationale: "Lang model swap in canary shows consistent quality uplift with lower token spend.",
-    owner: "Support Ops",
-    due: "Ready for rollout",
-  },
-  {
-    title: "Enable Retrieval Cache for Revenue Ops",
-    impact: "-$12k monthly / latency -18%",
-    rationale: "High repeat queries detected on fiscal planning scenarios.",
-    owner: "Ops Automation Guild",
-    due: "Pilot scheduled",
-  },
-  {
-    title: "Tighten Vendor Risk Guardrail",
-    impact: "Reduce false positives by 22%",
-    rationale: "Policy evaluation shows over-triggering on low risk suppliers.",
-    owner: "Enterprise Trust",
-    due: "Needs legal review",
-  },
-];
-
-const policies = [
-  {
-    name: "PII Safe Handling",
-    coverage: "Global",
-    status: "green",
-    description: "Auto-redaction enforced across CRM, ERP, and support transcripts.",
-    lastAudit: "6h ago",
-  },
-  {
-    name: "GDPR Residency",
-    coverage: "EU Region",
-    status: "green",
-    description: "Geo-fenced storage and inference enforced via AI Gateway policies.",
-    lastAudit: "2h ago",
-  },
-  {
-    name: "Bias Monitoring",
-    coverage: "People Ops",
-    status: "orange",
-    description: "Drift detected on fairness metrics for Talent Mobility Advisor.",
-    lastAudit: "20m ago",
-  },
-  {
-    name: "Incident Response",
-    coverage: "Enterprise",
-    status: "green",
-    description: "SOAR playbooks executed with 99% SLA adherence.",
-    lastAudit: "11h ago",
-  },
-];
-
-const experiments = [
-  {
-    name: "Support Agent Model Swap",
-    status: "Running",
-    detail: "A/B testing GPT-4o vs. Claude Opus for refund workflows.",
-    completion: 64,
-  },
-  {
-    name: "Revenue Plan Strategy",
-    status: "Canary",
-    detail: "Tool sequencing variant with scenario caching enabled.",
-    completion: 32,
-  },
-  {
-    name: "Risk Policy Tuning",
-    status: "Design",
-    detail: "Notebook-driven evals on supplier onboarding accuracy.",
-    completion: 18,
-  },
-];
 
 const telemetry = [
   "Ops | Supply Chain Navigator latency spike mitigated via cache warm-up.",
@@ -364,9 +56,6 @@ function wireNavigation() {
     button.addEventListener("click", () => {
       if (button.dataset.module === state.module) return;
       state.module = button.dataset.module;
-      state.detailView = "profile";
-      state.agentPage = false;
-      state.selectedAgent = null;
       document
         .querySelectorAll(".nav-item")
         .forEach((item) => item.classList.remove("active"));
@@ -480,22 +169,16 @@ function renderFilters() {
 
   panel.querySelector("#status-filter").addEventListener("change", (event) => {
     state.filters.status = event.target.value;
-    state.agentPage = false;
-    state.selectedAgent = null;
     renderModule();
   });
 
   panel.querySelector("#bu-filter").addEventListener("change", (event) => {
     state.filters.businessUnit = event.target.value;
-    state.agentPage = false;
-    state.selectedAgent = null;
     renderModule();
   });
 
   panel.querySelector("#risk-filter").addEventListener("change", (event) => {
     state.filters.risk = event.target.value;
-    state.agentPage = false;
-    state.selectedAgent = null;
     renderModule();
   });
 }
@@ -513,16 +196,6 @@ function applyAgentFilters(list) {
 
 function renderInventoryModule(container) {
   const filteredAgents = applyAgentFilters(agents);
-
-  if (state.agentPage && (!state.selectedAgent || !filteredAgents.find((agent) => agent.id === state.selectedAgent))) {
-    state.agentPage = false;
-    state.selectedAgent = filteredAgents[0]?.id ?? null;
-  }
-
-  if (state.agentPage && state.selectedAgent) {
-    renderAgentPage(container);
-    return;
-  }
 
   const boardHeader = document.createElement("section");
   boardHeader.className = "inventory-overview";
@@ -656,6 +329,8 @@ function renderInventoryModule(container) {
 function buildAgentTile(agent) {
   const card = document.createElement("article");
   card.className = `agent-tile risk-${agent.riskLevel}`;
+  card.tabIndex = 0;
+  card.setAttribute("role", "button");
   card.innerHTML = `
     <header>
       <div>
@@ -684,215 +359,24 @@ function buildAgentTile(agent) {
     </footer>
   `;
 
+  const openAgent = () => {
+    window.location.href = `agent.html?id=${encodeURIComponent(agent.id)}`;
+  };
+
   card.querySelector(".tile-open").addEventListener("click", (event) => {
     event.stopPropagation();
-    state.selectedAgent = agent.id;
-    state.detailView = "profile";
-    state.agentPage = true;
-    renderModule();
+    openAgent();
   });
 
-  card.addEventListener("click", () => {
-    state.selectedAgent = agent.id;
-    state.detailView = "profile";
-    state.agentPage = true;
-    renderModule();
+  card.addEventListener("click", openAgent);
+  card.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openAgent();
+    }
   });
 
   return card;
-}
-
-function renderAgentPage(container) {
-  const agent = agents.find((item) => item.id === state.selectedAgent);
-  if (!agent) {
-    state.agentPage = false;
-    renderInventoryModule(container);
-    return;
-  }
-
-  const page = document.createElement("section");
-  page.className = "agent-page";
-  page.innerHTML = `
-    <button class="ghost-btn back-button" type="button">← Back to inventory</button>
-    <header class="agent-hero">
-      <div>
-        <span class="muted">${agent.id}</span>
-        <h3>${agent.name}</h3>
-        <div class="agent-hero-meta">
-          <span>${agent.businessUnit}</span>
-          <span>${agent.owner}</span>
-          <span class="risk-chip risk-${agent.riskLevel}">Risk: ${agent.riskLevel.toUpperCase()}</span>
-        </div>
-      </div>
-      <div class="agent-hero-actions">
-        <span class="status-pill ${statusToColor(agent.status)}">${agent.status.toUpperCase()}</span>
-        <div class="hero-buttons">
-          <button class="primary-btn" type="button">Launch Playbook</button>
-          <button class="ghost-btn" type="button">Pause Agent</button>
-          <button class="ghost-btn" type="button">Escalate</button>
-        </div>
-      </div>
-    </header>
-    <section class="agent-metric-band">
-      ${[
-        { label: "Success Rate", value: `${Math.round(agent.successRate * 100)}%` },
-        { label: "Automation", value: `${Math.round(agent.automationRate * 100)}%` },
-        { label: "Average Latency", value: `${agent.avgLatency}s` },
-        { label: "Hours Saved", value: agent.hoursSaved.toLocaleString() },
-        { label: "Last Incident", value: agent.lastIncident },
-      ]
-        .map(
-          (item) => `
-            <article>
-              <span>${item.label}</span>
-              <strong>${item.value}</strong>
-            </article>
-          `
-        )
-        .join("")}
-    </section>
-    <div class="agent-page-grid">
-      <section class="agent-core">
-        <nav class="detail-switcher">
-          <button class="ghost-btn ${state.detailView === "profile" ? "active" : ""}" data-view="profile" type="button">Run Log</button>
-          <button class="ghost-btn ${state.detailView === "dependencies" ? "active" : ""}" data-view="dependencies" type="button">Dependency Graph</button>
-          <button class="ghost-btn ${state.detailView === "guardrails" ? "active" : ""}" data-view="guardrails" type="button">Guardrails</button>
-        </nav>
-        <div class="detail-body" id="detail-body"></div>
-      </section>
-      <aside class="agent-side">
-        <article class="detail-card">
-          <h4>Operational Checklist</h4>
-          <ul class="checklist">
-            <li>Blast radius reviewed</li>
-            <li>Guardrail pack synced</li>
-            <li>Escalation rota acknowledged</li>
-            <li>Telemetry routed to observability hub</li>
-          </ul>
-        </article>
-        <article class="detail-card">
-          <h4>Recent Activity</h4>
-          <div class="timeline">${agent.recentActivity
-            .map((entry) => `<div class="timeline-item">${entry}</div>`)
-            .join("")}</div>
-        </article>
-      </aside>
-    </div>
-  `;
-
-  page.querySelector(".back-button").addEventListener("click", () => {
-    state.agentPage = false;
-    renderModule();
-  });
-
-  page.querySelectorAll(".detail-switcher .ghost-btn").forEach((button) => {
-    button.addEventListener("click", () => {
-      state.detailView = button.dataset.view;
-      renderAgentPage(container);
-    });
-  });
-
-  container.appendChild(page);
-
-  const body = page.querySelector("#detail-body");
-  if (state.detailView === "dependencies") {
-    body.innerHTML = renderDependencies(agent);
-  } else if (state.detailView === "guardrails") {
-    body.innerHTML = renderGuardrails(agent.guardrails);
-  } else {
-    body.innerHTML = renderRunLog(agent.recentActivity);
-  }
-}
-
-function renderDependencies(agent) {
-  return `
-    <div class="detail-card nested">
-      <h4>Dependencies</h4>
-      <p class="muted">Visualize upstream tools and guardrails before deploying changes.</p>
-      <div class="badge-grid">
-        ${agent.dependencies.tools.map((tool) => `<span class="chip">🛠 ${tool}</span>`).join("")}
-      </div>
-      <div class="badge-grid">
-        ${agent.dependencies.connectors
-          .map((connector) => `<span class="chip">🔌 ${connector}</span>`)
-          .join("")}
-      </div>
-      <div class="badge-grid">
-        ${agent.dependencies.policies.map((policy) => `<span class="chip">🛡 ${policy}</span>`).join("")}
-      </div>
-      <p class="muted">Use blast radius analysis before editing shared resources.</p>
-    </div>
-  `;
-}
-
-function renderGuardrails(items) {
-  return `
-    <div class="detail-card nested">
-      <h4>Guardrail Health</h4>
-      <div class="policy-grid">
-        ${items
-          .map(
-            (item) => `
-              <div class="policy-card">
-                <header>
-                  <strong>${item.name}</strong>
-                  <span class="status-pill ${statusToColor(item.status)}">${item.status.toUpperCase()}</span>
-                </header>
-                <p class="muted">${guardrailCopy(item.status)}</p>
-              </div>
-            `
-          )
-          .join("")}
-      </div>
-    </div>
-  `;
-}
-
-function renderRunLog(activity) {
-  return `
-    <div class="detail-card nested">
-      <h4>Latest Activity</h4>
-      <div class="timeline">
-        ${activity.map((entry) => `<div class="timeline-item">${entry}</div>`).join("")}
-      </div>
-    </div>
-  `;
-}
-
-function statusToColor(status) {
-  switch (status) {
-    case "active":
-    case "running":
-    case "completed":
-    case "resolved":
-      return "green";
-    case "paused":
-    case "canary":
-    case "design":
-    case "investigating":
-    case "pending":
-    case "orange":
-      return "orange";
-    case "failed":
-    case "escalated":
-    case "red":
-      return "red";
-    default:
-      return "orange";
-  }
-}
-
-function guardrailCopy(status) {
-  switch (status) {
-    case "green":
-      return "Operating within expected thresholds.";
-    case "orange":
-      return "Degradation detected. Review evaluation notebook.";
-    case "red":
-      return "Policy violation. HITL approval required before restart.";
-    default:
-      return "Monitoring.";
-  }
 }
 
 function renderHitlModule(container) {
@@ -1124,7 +608,7 @@ style.textContent = `
   .experiment-meta { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
   .progress { flex: 1; height: 6px; border-radius: 999px; background: rgba(37, 99, 235, 0.12); overflow: hidden; }
   .progress-bar { height: 100%; background: linear-gradient(90deg, rgba(37, 99, 235, 0.8), rgba(59, 130, 246, 0.9)); }
-  .agent-card.active-selection { outline: 1px solid rgba(37, 99, 235, 0.35); box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12); }
+  .agent-tile:hover, .agent-tile:focus-within { outline: 1px solid rgba(37, 99, 235, 0.35); box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12); }
   #filter-panel { display: grid; gap: 12px; }
   .filter { display: grid; gap: 6px; font-size: 0.85rem; color: var(--text-muted); }
   .filter select { background: var(--surface); border: 1px solid var(--border-soft); border-radius: var(--radius-sm); padding: 8px; color: var(--text-primary); }

--- a/data.js
+++ b/data.js
@@ -1,0 +1,885 @@
+export const copy = {
+  inventory: {
+    title: "Inventory Manager",
+    subtitle: "Real-time view of deployed agents, their state, and health.",
+  },
+  hitl: {
+    title: "Human-in-the-Loop Console",
+    subtitle: "Route escalations, manage approvals, and keep SLAs on track.",
+  },
+  insights: {
+    title: "Outcome Insights",
+    subtitle: "Quantify business impact and surface levers for improvement.",
+  },
+  governance: {
+    title: "Governance & Guardrails",
+    subtitle: "Ensure policies travel with agents and every decision is auditable.",
+  },
+  optimization: {
+    title: "Optimization Lab",
+    subtitle: "Experiment, tune, and control cost-quality tradeoffs at scale.",
+  },
+};
+
+export const agents = [
+  {
+    id: "AIOPS-017",
+    name: "Revenue Ops Planner",
+    status: "active",
+    businessUnit: "Go-To-Market",
+    owner: "Ops Automation Guild",
+    successRate: 0.94,
+    automationRate: 0.81,
+    avgLatency: 6.2,
+    hoursSaved: 4820,
+    lastIncident: "12d ago",
+    riskLevel: "medium",
+    adoption: "Global Sales",
+    dependencies: {
+      tools: ["Salesforce", "Tableau", "SAP"],
+      connectors: ["Databricks Lakehouse", "Palantir AIP"],
+      policies: ["SOX Controls", "PII Masking"],
+    },
+    guardrails: [
+      { name: "Financial Data Boundary", status: "green" },
+      { name: "Revenue Forecast Review", status: "orange" },
+    ],
+    recentActivity: [
+      "Generated Q4 revenue coverage plan",
+      "Escalated contract anomaly to finance reviewer",
+      "Rolled back retrieval model after canary drift",
+    ],
+    hitl: {
+      queue: [
+        {
+          id: "HITL-9043",
+          title: "Approve LATAM scenario override",
+          description:
+            "Forecast variance above 8% for LATAM enterprise deals requires controller review before publishing.",
+          sla: "1h 20m",
+          assignee: "Finance Controller",
+          channel: "Slack",
+          status: "pending",
+        },
+        {
+          id: "HITL-9051",
+          title: "Validate token spend budget",
+          description:
+            "Model requested budget uplift of $18k for GPT-4o usage in Q3 acceleration program.",
+          sla: "3h 15m",
+          assignee: "Ops Automation Guild",
+          channel: "Email",
+          status: "pending",
+        },
+        {
+          id: "HITL-8991",
+          title: "Investigate procurement anomaly",
+          description:
+            "Supplier onboarding stalled after policy guardrail flagged missing compliance attachment.",
+          sla: "45m",
+          assignee: "Enterprise Trust",
+          channel: "ServiceNow",
+          status: "investigating",
+        },
+      ],
+      decisionLog: [
+        "2024-07-17 08:42 • Finance approved scenario variant C",
+        "2024-07-16 17:10 • Controller requested human review on procurement anomaly",
+        "2024-07-15 12:05 • Ops accepted automated budget rebalancing recommendation",
+      ],
+      playbooks: [
+        "Scenario override reviewer workflow",
+        "Token spend budget guardrail",
+        "Procurement anomaly warm handoff",
+      ],
+    },
+    performance: {
+      metrics: [
+        { label: "Successful Runs (7d)", value: "486", trend: "+8% vs. prior" },
+        { label: "Human Reviews", value: "14", trend: "-3 vs. last week" },
+        { label: "Avg. Cycle Time", value: "5.8 min", trend: "-0.6 min" },
+        { label: "Token Spend", value: "$4.6k", trend: "+$180" },
+      ],
+      errorBreakdown: [
+        { label: "Policy Violations", count: 2, change: "-1 vs. last week" },
+        { label: "Data Quality Checks", count: 5, change: "+1" },
+        { label: "External API Failures", count: 3, change: "Stable" },
+      ],
+      incidents: [
+        {
+          timestamp: "2024-07-17 07:55",
+          summary: "Guardrail intercepted regional override and requested manual review.",
+          resolution: "Finance controller approved after verifying upstream CRM delta.",
+        },
+        {
+          timestamp: "2024-07-14 21:20",
+          summary: "Databricks ingestion delay increased latency for nightly scenario runs.",
+          resolution: "Cache pre-warming policy applied and run rescheduled.",
+        },
+        {
+          timestamp: "2024-07-13 10:42",
+          summary: "Token budget threshold reached for EMEA pipeline expansion.",
+          resolution: "Ops authorized additional spend with monitoring flag.",
+        },
+      ],
+      evaluationNotes: [
+        "QLoRA fine-tune continues outperforming baseline at 1.9% lower cost-per-run.",
+        "Need deeper coverage on procurement datasets for vendor onboarding edge cases.",
+        "Introduce shared evaluation harness with Sales Ops to align on success definition.",
+      ],
+    },
+    insights: {
+      narrative:
+        "Revenue variance has stabilized, but human approvals are clustered around procurement anomalies. Focus on upstream data hygiene to keep automation rate climbing.",
+      actions: [
+        {
+          title: "Publish procurement anomaly checklist",
+          description: "Codify finance reviewer steps into shared Confluence playbook and sync to agent.",
+          impact: "Reduce manual review time by 18%",
+          owner: "Enterprise Trust",
+          due: "This week",
+          status: "In Flight",
+        },
+        {
+          title: "Enable retrieval cache for repeated forecast queries",
+          description: "Cache top 50 scenario prompts to trim Databricks reads on peak days.",
+          impact: "Save ~$1.8k monthly",
+          owner: "Ops Automation Guild",
+          due: "Next sprint",
+          status: "Ready",
+        },
+        {
+          title: "Pair with GTM analytics on shared eval set",
+          description: "Align fairness and accuracy metrics for expansion into channel sales.",
+          impact: "Unlock 3 new workflows",
+          owner: "GTM Analytics",
+          due: "End of month",
+          status: "Planned",
+        },
+      ],
+      opportunities: [
+        { label: "Scenario coverage", detail: "Add FY25 partner tier logic to reduce overrides." },
+        { label: "Data freshness", detail: "Schedule CRM ingestion monitor at 30-minute cadence." },
+        { label: "Playbook reuse", detail: "Share procurement handoff template with Supply Chain Navigator." },
+      ],
+    },
+  },
+  {
+    id: "CX-204",
+    name: "Customer Care Orchestrator",
+    status: "active",
+    businessUnit: "Customer Experience",
+    owner: "Support Ops",
+    successRate: 0.89,
+    automationRate: 0.74,
+    avgLatency: 3.8,
+    hoursSaved: 6950,
+    lastIncident: "3d ago",
+    riskLevel: "low",
+    adoption: "Tier 1 & 2 Support",
+    dependencies: {
+      tools: ["Zendesk", "Slack", "ServiceNow"],
+      connectors: ["LangSmith", "Mosaic Gateway"],
+      policies: ["GDPR Privacy Pack", "PCI Redaction"],
+    },
+    guardrails: [
+      { name: "EU Data Residency", status: "green" },
+      { name: "Payment Redaction", status: "green" },
+    ],
+    recentActivity: [
+      "Deflected billing ticket with self-service workflow",
+      "Routed outage escalation to on-call engineer",
+      "Captured CSAT feedback into evaluation dataset",
+    ],
+    hitl: {
+      queue: [
+        {
+          id: "HITL-8120",
+          title: "VIP refund approval",
+          description:
+            "High-value customer requested manual override for refund outside policy window.",
+          sla: "35m",
+          assignee: "Regional Support Lead",
+          channel: "ServiceNow",
+          status: "pending",
+        },
+        {
+          id: "HITL-8109",
+          title: "Language handoff",
+          description:
+            "Conversation detected sentiment drift in Japanese; requires bilingual specialist review.",
+          sla: "1h 10m",
+          assignee: "APAC Support Desk",
+          channel: "Slack",
+          status: "pending",
+        },
+        {
+          id: "HITL-8066",
+          title: "PCI evidence confirmation",
+          description:
+            "Agent auto-redacted card details; compliance team to confirm transcript for quarterly audit.",
+          sla: "6h",
+          assignee: "Compliance QA",
+          channel: "Jira",
+          status: "completed",
+        },
+      ],
+      decisionLog: [
+        "2024-07-17 09:14 • VIP refund granted with exception flag",
+        "2024-07-16 19:40 • Compliance QA closed PCI review with no findings",
+        "2024-07-15 08:05 • Shift lead approved language handoff to specialist queue",
+      ],
+      playbooks: [
+        "Refund exception routing",
+        "Live sentiment intervention",
+        "PCI audit preparation",
+      ],
+    },
+    performance: {
+      metrics: [
+        { label: "Deflection Rate", value: "64%", trend: "+5 pts" },
+        { label: "Average Handle Time", value: "2.9 min", trend: "-0.4 min" },
+        { label: "Escalations", value: "22", trend: "-6" },
+        { label: "CSAT", value: "4.7 / 5", trend: "+0.3" },
+      ],
+      errorBreakdown: [
+        { label: "Policy Exceptions", count: 3, change: "Stable" },
+        { label: "Tool Failures", count: 1, change: "-2" },
+        { label: "Language Mismatches", count: 4, change: "-1" },
+      ],
+      incidents: [
+        {
+          timestamp: "2024-07-16 18:50",
+          summary: "VIP refund flagged due to contract exception rules.",
+          resolution: "Manual approval recorded and playbook updated with new clause.",
+        },
+        {
+          timestamp: "2024-07-15 06:30",
+          summary: "Japanese sentiment model drifted after rollout of new taxonomy.",
+          resolution: "Fallback to human specialist for 12 hours while model retrained.",
+        },
+        {
+          timestamp: "2024-07-12 23:18",
+          summary: "Zendesk API rate limits slowed queue updates.",
+          resolution: "Enabled adaptive polling schedule during incident window.",
+        },
+      ],
+      evaluationNotes: [
+        "Tier 3 workflows ready for automation once legal approves new knowledge articles.",
+        "Need coverage for weekend hours when bilingual specialists are offline.",
+        "Consider adding translation confidence metric to dashboard.",
+      ],
+    },
+    insights: {
+      narrative:
+        "Customer Care Orchestrator continues to reduce handle time. Human reviews mostly concern policy exceptions that can be codified into new guardrails.",
+      actions: [
+        {
+          title: "Automate VIP refund guardrail",
+          description: "Convert exception criteria into structured policy so only approvals require human touch.",
+          impact: "Cut VIP queue by 40%",
+          owner: "Support Ops",
+          due: "48 hours",
+          status: "In Review",
+        },
+        {
+          title: "Expand bilingual coverage",
+          description: "Staff APAC specialists for weekend handoffs and add fallback vendor for after-hours.",
+          impact: "Remove 3 manual escalations per day",
+          owner: "CX Workforce Mgmt",
+          due: "Next staffing cycle",
+          status: "Planned",
+        },
+        {
+          title: "Launch CSAT-driven experiment",
+          description: "Run 2-week A/B test on proactive knowledge suggestions in self-service flows.",
+          impact: "+1.5 CSAT target",
+          owner: "Knowledge Ops",
+          due: "Aug 1",
+          status: "Scheduled",
+        },
+      ],
+      opportunities: [
+        { label: "Knowledge freshness", detail: "Sync release notes into self-service flows daily." },
+        { label: "Compliance automation", detail: "Auto-attach PCI transcripts to quarterly audit packs." },
+        { label: "Sentiment guardrail", detail: "Deploy fallback for low confidence translations." },
+      ],
+    },
+  },
+  {
+    id: "RISK-88",
+    name: "Third-Party Risk Analyst",
+    status: "paused",
+    businessUnit: "Risk & Compliance",
+    owner: "Enterprise Trust",
+    successRate: 0.76,
+    automationRate: 0.52,
+    avgLatency: 12.5,
+    hoursSaved: 1830,
+    lastIncident: "2h ago",
+    riskLevel: "high",
+    adoption: "Vendor Management",
+    dependencies: {
+      tools: ["GRC Vault", "DocuSign"],
+      connectors: ["AI Gateway", "Policy Engine"],
+      policies: ["AI Act Tier 2", "Vendor Risk Guardrails"],
+    },
+    guardrails: [
+      { name: "Sensitive Document Access", status: "red" },
+      { name: "Dual Control", status: "orange" },
+    ],
+    recentActivity: [
+      "Paused after exceeding false positive threshold",
+      "Requested manual review for procurement contract",
+      "Generated audit evidence pack for Q3",
+    ],
+    hitl: {
+      queue: [
+        {
+          id: "HITL-7201",
+          title: "Legal interpretation required",
+          description:
+            "Clause 14.2 conflict with latest AI Act guidance; needs human counsel sign-off before release.",
+          sla: "2h 10m",
+          assignee: "Enterprise Legal",
+          channel: "Jira",
+          status: "pending",
+        },
+        {
+          id: "HITL-7210",
+          title: "Risk scoring override",
+          description:
+            "False positive triggered for low-risk supplier after sanctions list update. Validate scoring weights.",
+          sla: "55m",
+          assignee: "Risk Operations",
+          channel: "Email",
+          status: "pending",
+        },
+        {
+          id: "HITL-7188",
+          title: "DocuSign contract attachment missing",
+          description:
+            "Vendor failed to upload cybersecurity questionnaire; manual outreach required.",
+          sla: "4h",
+          assignee: "Vendor Management",
+          channel: "ServiceNow",
+          status: "escalated",
+        },
+      ],
+      decisionLog: [
+        "2024-07-17 06:30 • Agent paused automatically after policy violation",
+        "2024-07-16 15:24 • Legal added interim language to clause 14.2",
+        "2024-07-15 09:12 • Risk Ops reset scoring weights after sanctions data update",
+      ],
+      playbooks: [
+        "Dual control evidence capture",
+        "Sanctions data reconciliation",
+        "Contract clause interpretation",
+      ],
+    },
+    performance: {
+      metrics: [
+        { label: "Vendors Processed", value: "84", trend: "-12% vs. target" },
+        { label: "False Positives", value: "29", trend: "+6" },
+        { label: "Manual Reviews", value: "41", trend: "+12" },
+        { label: "Average SLA", value: "18.4 hrs", trend: "+4.1 hrs" },
+      ],
+      errorBreakdown: [
+        { label: "Policy Violations", count: 7, change: "+3" },
+        { label: "Document Missing", count: 11, change: "+5" },
+        { label: "Model Drift", count: 4, change: "+2" },
+      ],
+      incidents: [
+        {
+          timestamp: "2024-07-17 06:28",
+          summary: "Policy engine flagged cross-border data transfer risk and paused agent.",
+          resolution: "Awaiting legal approval after manual remediation steps.",
+        },
+        {
+          timestamp: "2024-07-16 15:15",
+          summary: "Sanctions list update inflated risk scores for 34 vendors.",
+          resolution: "Risk Ops reweighted features and queued reruns.",
+        },
+        {
+          timestamp: "2024-07-14 11:02",
+          summary: "Vendor questionnaire ingestion failed due to document schema change.",
+          resolution: "Fallback template deployed with manual verification for affected vendors.",
+        },
+      ],
+      evaluationNotes: [
+        "Need to retrain classification head with latest legal annotations to reduce clause escalations.",
+        "Introduce dual-review guardrail automation to unblock low-risk renewals.",
+        "Expand telemetry to capture vendor-provided document schema variants.",
+      ],
+    },
+    insights: {
+      narrative:
+        "Third-Party Risk Analyst is paused due to compliance guardrail hits. False positives and document completeness are the main blockers to restoring autonomy.",
+      actions: [
+        {
+          title: "Stand up compliance tiger team",
+          description: "Pair legal, risk ops, and vendor management for 72-hour remediation sprint.",
+          impact: "Resume agent with dual control intact",
+          owner: "Enterprise Trust",
+          due: "Today",
+          status: "Critical",
+        },
+        {
+          title: "Automate document reminder sequence",
+          description: "Trigger DocuSign follow-ups and Slack reminders for missing questionnaires.",
+          impact: "Reduce manual outreach by 60%",
+          owner: "Vendor Management",
+          due: "This week",
+          status: "In Build",
+        },
+        {
+          title: "Retrain policy classifier",
+          description: "Augment training data with latest AI Act interpretations from legal counsel.",
+          impact: "Cut policy violations by half",
+          owner: "Risk Ops ML",
+          due: "Sprint +1",
+          status: "Planned",
+        },
+      ],
+      opportunities: [
+        { label: "Document AI", detail: "Leverage OCR to normalize questionnaires across vendors." },
+        { label: "Policy sandbox", detail: "Test new clause templates in offline environment before promotion." },
+        { label: "Feedback loop", detail: "Reward reviewers who clear backlog with fewer escalations." },
+      ],
+    },
+  },
+  {
+    id: "SUPPLY-61",
+    name: "Supply Chain Navigator",
+    status: "active",
+    businessUnit: "Operations",
+    owner: "Fulfillment PMO",
+    successRate: 0.91,
+    automationRate: 0.68,
+    avgLatency: 8.4,
+    hoursSaved: 3810,
+    lastIncident: "7d ago",
+    riskLevel: "medium",
+    adoption: "Global Logistics",
+    dependencies: {
+      tools: ["SAP IBP", "Snowflake"],
+      connectors: ["Mosaic Gateway", "Vertex Forecast API"],
+      policies: ["Export Control", "Supplier Compliance"],
+    },
+    guardrails: [
+      { name: "Cold Chain Policy", status: "green" },
+      { name: "Supplier Risk", status: "green" },
+    ],
+    recentActivity: [
+      "Predicted port congestion impact for APAC",
+      "Triggered alternate route automation",
+      "Logged scenario to optimization notebook",
+    ],
+    hitl: {
+      queue: [
+        {
+          id: "HITL-6404",
+          title: "Confirm cold-chain variance",
+          description:
+            "Temperature monitor flagged slight variance on refrigerated shipment; needs ops manager review.",
+          sla: "50m",
+          assignee: "Regional Logistics",
+          channel: "PagerDuty",
+          status: "pending",
+        },
+        {
+          id: "HITL-6398",
+          title: "Carrier substitution approval",
+          description:
+            "Agent recommending alternate carrier due to port congestion for Shanghai lane.",
+          sla: "2h",
+          assignee: "Transportation Lead",
+          channel: "Slack",
+          status: "pending",
+        },
+        {
+          id: "HITL-6385",
+          title: "Supplier compliance follow-up",
+          description:
+            "Need manual verification that supplier uploaded updated ISO certifications.",
+          sla: "6h",
+          assignee: "Supplier Quality",
+          channel: "Email",
+          status: "completed",
+        },
+      ],
+      decisionLog: [
+        "2024-07-16 16:55 • Alternate carrier approved for Shanghai lane",
+        "2024-07-15 11:22 • Supplier quality confirmed ISO cert upload",
+        "2024-07-14 07:05 • Ops cleared cold-chain variance after sensor recalibration",
+      ],
+      playbooks: [
+        "Cold-chain variance response",
+        "Carrier substitution evaluation",
+        "Supplier compliance validation",
+      ],
+    },
+    performance: {
+      metrics: [
+        { label: "On-time Deliveries", value: "96%", trend: "+3 pts" },
+        { label: "Exception Rate", value: "11%", trend: "-2 pts" },
+        { label: "Inventory Carry", value: "28 days", trend: "-1.5 days" },
+        { label: "Scenario Runs", value: "312", trend: "+24" },
+      ],
+      errorBreakdown: [
+        { label: "Sensor Variance", count: 4, change: "-1" },
+        { label: "Data Latency", count: 6, change: "+2" },
+        { label: "Supplier Docs", count: 2, change: "Stable" },
+      ],
+      incidents: [
+        {
+          timestamp: "2024-07-16 16:40",
+          summary: "Congestion index spiked for Shanghai causing reroute recommendation.",
+          resolution: "Transportation lead validated cost impact and approved new carrier mix.",
+        },
+        {
+          timestamp: "2024-07-14 06:50",
+          summary: "Cold chain sensor produced false positive due to calibration drift.",
+          resolution: "Technician recalibrated sensors and agent resumed automated routing.",
+        },
+        {
+          timestamp: "2024-07-12 03:10",
+          summary: "Snowflake sync lagged causing stale inventory snapshot.",
+          resolution: "Enabled incremental sync and reran affected scenarios.",
+        },
+      ],
+      evaluationNotes: [
+        "Need to expose congestion confidence intervals to transportation planners.",
+        "Explore synthetic data augmentation for low-volume shipping lanes.",
+        "Add upstream alert when Snowflake sync lags beyond 5 minutes.",
+      ],
+    },
+    insights: {
+      narrative:
+        "Supply Chain Navigator is driving on-time delivery improvements. HITL interactions revolve around risk-sensitive logistics changes that can be templated for faster approval.",
+      actions: [
+        {
+          title: "Pre-authorize carrier substitutions",
+          description: "Define guardrail thresholds where alternate carrier choices auto-approve when cost delta <5%.",
+          impact: "Shrink approval cycle by 30%",
+          owner: "Transportation Lead",
+          due: "Next ops review",
+          status: "Drafting",
+        },
+        {
+          title: "Instrument congestion confidence",
+          description: "Publish daily congestion confidence intervals directly in planner UI.",
+          impact: "Increase planner trust",
+          owner: "Supply Analytics",
+          due: "Sprint +1",
+          status: "In Design",
+        },
+        {
+          title: "Automate sensor recalibration alerts",
+          description: "Tie IoT diagnostics into observability hub for proactive calibration scheduling.",
+          impact: "Remove 2 manual interventions/week",
+          owner: "IoT Engineering",
+          due: "Aug 5",
+          status: "Planned",
+        },
+      ],
+      opportunities: [
+        { label: "Scenario library", detail: "Add near-shore manufacturing scenario set." },
+        { label: "Supplier insights", detail: "Share compliance telemetry with vendor portal." },
+        { label: "Ops training", detail: "Include AI agent orientation in new hire bootcamp." },
+      ],
+    },
+  },
+  {
+    id: "HR-142",
+    name: "Talent Mobility Advisor",
+    status: "failed",
+    businessUnit: "People",
+    owner: "HR Innovation",
+    successRate: 0.63,
+    automationRate: 0.41,
+    avgLatency: 5.9,
+    hoursSaved: 940,
+    lastIncident: "12m ago",
+    riskLevel: "medium",
+    adoption: "Corporate HR",
+    dependencies: {
+      tools: ["Workday", "Greenhouse"],
+      connectors: ["AI Gateway", "Employee Graph"],
+      policies: ["PII Safe Handling", "Bias Monitoring"],
+    },
+    guardrails: [
+      { name: "Bias Monitoring", status: "red" },
+      { name: "PII Masking", status: "orange" },
+    ],
+    recentActivity: [
+      "Failed to complete internal transfer recommendation",
+      "Escalated to HRBP for manual approval",
+      "Opened eval notebook for fairness regression",
+    ],
+    hitl: {
+      queue: [
+        {
+          id: "HITL-5409",
+          title: "Bias remediation approval",
+          description:
+            "Fairness regression flagged for engineering candidates; need HRBP confirmation before restart.",
+          sla: "1h",
+          assignee: "HR Business Partner",
+          channel: "Slack",
+          status: "pending",
+        },
+        {
+          id: "HITL-5413",
+          title: "PII redaction audit",
+          description:
+            "Sampled transcripts require verification that masking worked prior to compliance submission.",
+          sla: "3h",
+          assignee: "Privacy Office",
+          channel: "Jira",
+          status: "pending",
+        },
+        {
+          id: "HITL-5388",
+          title: "Model rollback validation",
+          description:
+            "Need sign-off that fallback model meets fairness baseline before agent resumes.",
+          sla: "4h",
+          assignee: "Responsible AI Council",
+          channel: "Email",
+          status: "escalated",
+        },
+      ],
+      decisionLog: [
+        "2024-07-17 09:02 • Agent halted after fairness regression breached threshold",
+        "2024-07-16 13:48 • Privacy team initiated deep dive on masking efficacy",
+        "2024-07-15 18:05 • Responsible AI Council requested expanded audit sample",
+      ],
+      playbooks: [
+        "Bias remediation workflow",
+        "PII masking verification",
+        "Model rollback governance",
+      ],
+    },
+    performance: {
+      metrics: [
+        { label: "Recommendations Delivered", value: "118", trend: "-22%" },
+        { label: "Approvals Required", value: "61", trend: "+18" },
+        { label: "Fairness Delta", value: "+6.1 pts", trend: "+3.4" },
+        { label: "PII Violations", value: "4", trend: "+2" },
+      ],
+      errorBreakdown: [
+        { label: "Fairness Alerts", count: 9, change: "+5" },
+        { label: "Data Quality", count: 3, change: "+1" },
+        { label: "Policy Breaches", count: 4, change: "+2" },
+      ],
+      incidents: [
+        {
+          timestamp: "2024-07-17 08:50",
+          summary: "Bias monitoring detected regression on technical hiring recommendations.",
+          resolution: "Agent failed closed; awaiting human review of mitigation plan.",
+        },
+        {
+          timestamp: "2024-07-16 12:10",
+          summary: "Privacy audit found inconsistent masking of phone numbers in transcripts.",
+          resolution: "Escalated to privacy office for manual inspection and patch.",
+        },
+        {
+          timestamp: "2024-07-14 20:45",
+          summary: "Fallback model failed to meet fairness baseline during evaluation run.",
+          resolution: "Responsible AI Council requested expanded dataset prior to restart.",
+        },
+      ],
+      evaluationNotes: [
+        "Need to retrain fairness classifier with balanced dataset focusing on technical roles.",
+        "Consider synthetic augmentation for underrepresented groups to stabilize metrics.",
+        "Automate PII masking smoke test as part of deployment pipeline.",
+      ],
+    },
+    insights: {
+      narrative:
+        "Talent Mobility Advisor is offline until fairness and privacy regressions are resolved. Humans are coordinating remediation across HR, privacy, and responsible AI teams.",
+      actions: [
+        {
+          title: "Launch fairness remediation sprint",
+          description: "Bring HR analytics and Responsible AI Council together for 48-hour working session.",
+          impact: "Restore fairness metrics within threshold",
+          owner: "HR Analytics",
+          due: "Today",
+          status: "Critical",
+        },
+        {
+          title: "Automate masking regression tests",
+          description: "Add deterministic redaction tests into CI/CD before each release.",
+          impact: "Prevent privacy regressions",
+          owner: "Platform Engineering",
+          due: "This sprint",
+          status: "In Build",
+        },
+        {
+          title: "Publish transparent postmortem",
+          description: "Share findings with employees and outline guardrail hardening plan.",
+          impact: "Rebuild trust",
+          owner: "HR Communications",
+          due: "Friday",
+          status: "Drafting",
+        },
+      ],
+      opportunities: [
+        { label: "Evaluation coverage", detail: "Expand fairness tests to lateral moves and contractor conversions." },
+        { label: "Explainability", detail: "Add SHAP-based rationale view for HR reviewers." },
+        { label: "Training data", detail: "Partner with TA to source fresh annotated examples." },
+      ],
+    },
+  },
+];
+
+export const actionQueue = [
+  {
+    id: "INC-4450",
+    title: "Procurement Contract Review",
+    summary: "Vendor clause flagged as ambiguous. Needs legal validation before execution.",
+    status: "pending",
+    sla: "02:15",
+    businessUnit: "Risk & Compliance",
+    workflow: "Third-Party Risk Analyst",
+    urgency: "high",
+  },
+  {
+    id: "INC-4412",
+    title: "Customer Refund Escalation",
+    summary: "High value customer requested manual override for refund exception.",
+    status: "pending",
+    sla: "00:42",
+    businessUnit: "Customer Experience",
+    workflow: "Customer Care Orchestrator",
+    urgency: "critical",
+  },
+  {
+    id: "INC-4390",
+    title: "AI Policy Drift",
+    summary: "Policy pack mismatch detected between staging and production gateways.",
+    status: "escalated",
+    sla: "04:20",
+    businessUnit: "Platform",
+    workflow: "Gateway Governance",
+    urgency: "medium",
+  },
+  {
+    id: "INC-4302",
+    title: "Forecast Accuracy Regression",
+    summary: "A/B test variant B regressed cost-to-serve by 6%.",
+    status: "investigating",
+    sla: "08:00",
+    businessUnit: "Operations",
+    workflow: "Supply Chain Navigator",
+    urgency: "medium",
+  },
+  {
+    id: "INC-4220",
+    title: "Successful Automation Review",
+    summary: "Bulk billing adjustments auto-approved with zero escalations for 48h.",
+    status: "completed",
+    sla: "--",
+    businessUnit: "Finance",
+    workflow: "Revenue Ops Planner",
+    urgency: "low",
+  },
+];
+
+export const insights = {
+  ops: [
+    { label: "Autonomy Rate", value: "78%", trend: "+6.2% vs last month" },
+    { label: "Average Time Saved", value: "11.4 hrs/task", trend: "+1.8 hrs" },
+    { label: "Escalation MTTR", value: "34 min", trend: "-12 min" },
+    { label: "Coverage", value: "146 agents", trend: "+18 onboarded" },
+  ],
+  exec: [
+    { label: "Hours Returned to Business", value: "38,420", trend: "+4,120 YoY" },
+    { label: "Net Cost Avoidance", value: "$7.9M", trend: "+$900k QoQ" },
+    { label: "CSAT Lift", value: "+9.4 pts", trend: "+1.1 pts" },
+    { label: "Adoption Velocity", value: "21 new teams", trend: "+5 vs target" },
+  ],
+  security: [
+    { label: "Policy Coverage", value: "98.4%", trend: "+0.8%" },
+    { label: "High Risk Agents", value: "4", trend: "-2 vs last week" },
+    { label: "Audit Evidence Packs", value: "27 ready", trend: "GDPR, HIPAA" },
+    { label: "Incident Containment", value: "< 6 min", trend: "SOAR auto-closure" },
+  ],
+};
+
+export const recommendations = [
+  {
+    title: "Promote Variant B for Customer Care",
+    impact: "+4.2% FCR / -3% cost",
+    rationale: "Lang model swap in canary shows consistent quality uplift with lower token spend.",
+    owner: "Support Ops",
+    due: "Ready for rollout",
+  },
+  {
+    title: "Enable Retrieval Cache for Revenue Ops",
+    impact: "-$12k monthly / latency -18%",
+    rationale: "High repeat queries detected on fiscal planning scenarios.",
+    owner: "Ops Automation Guild",
+    due: "Pilot scheduled",
+  },
+  {
+    title: "Tighten Vendor Risk Guardrail",
+    impact: "Reduce false positives by 22%",
+    rationale: "Policy evaluation shows over-triggering on low risk suppliers.",
+    owner: "Enterprise Trust",
+    due: "Needs legal review",
+  },
+];
+
+export const policies = [
+  {
+    name: "PII Safe Handling",
+    coverage: "Global",
+    status: "green",
+    description: "Auto-redaction enforced across CRM, ERP, and support transcripts.",
+    lastAudit: "6h ago",
+  },
+  {
+    name: "GDPR Residency",
+    coverage: "EU Region",
+    status: "green",
+    description: "Geo-fenced storage and inference enforced via AI Gateway policies.",
+    lastAudit: "2h ago",
+  },
+  {
+    name: "Bias Monitoring",
+    coverage: "People Ops",
+    status: "orange",
+    description: "Drift detected on fairness metrics for Talent Mobility Advisor.",
+    lastAudit: "20m ago",
+  },
+  {
+    name: "Incident Response",
+    coverage: "Enterprise",
+    status: "green",
+    description: "SOAR playbooks executed with 99% SLA adherence.",
+    lastAudit: "11h ago",
+  },
+];
+
+export const experiments = [
+  {
+    name: "Support Agent Model Swap",
+    status: "Running",
+    detail: "A/B testing GPT-4o vs. Claude Opus for refund workflows.",
+    completion: 64,
+  },
+  {
+    name: "Revenue Plan Strategy",
+    status: "Canary",
+    detail: "Tool sequencing variant with scenario caching enabled.",
+    completion: 32,
+  },
+  {
+    name: "Risk Policy Tuning",
+    status: "Design",
+    detail: "Notebook-driven evals on supplier onboarding accuracy.",
+    completion: 18,
+  },
+];

--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Agent Command Center</title>
+  <title>Global AI Agent Command Center</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <div class="app-shell">
     <aside class="sidebar">
       <div class="brand">
-        <span class="brand-acronym">ACC</span>
+        <span class="brand-acronym">GAACC</span>
         <div class="brand-details">
-          <h1>Agent Command Center</h1>
+          <h1>Global AI Agent Command Center</h1>
           <p>Mission Control for Enterprise AI</p>
         </div>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -575,21 +575,79 @@ body {
   color: var(--text-secondary);
 }
 
-.agent-page {
-  display: grid;
-  gap: 24px;
+.agent-page-body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(37, 99, 235, 0.12), transparent 55%), var(--bg-900);
 }
 
-.agent-hero {
+.agent-topbar {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
+  padding: 20px 32px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border-soft);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.topbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.topbar-brand .brand-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.topbar-brand .brand-copy strong {
+  font-size: 1.1rem;
+}
+
+.topbar-brand .brand-copy span {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.agent-main {
+  padding: 32px 36px 48px;
+  display: grid;
+  gap: 28px;
+}
+
+.agent-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.agent-detail-primary,
+.agent-detail-secondary {
+  display: grid;
   gap: 18px;
 }
 
-.agent-hero h3 {
+.agent-hero-card {
+  gap: 20px;
+}
+
+.agent-hero-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.agent-hero-header h1 {
   margin: 8px 0 0;
-  font-size: 1.8rem;
+  font-size: 2rem;
 }
 
 .agent-hero-meta {
@@ -597,11 +655,11 @@ body {
   flex-wrap: wrap;
   gap: 10px;
   margin-top: 12px;
-  color: var(--text-muted);
   font-size: 0.9rem;
+  color: var(--text-muted);
 }
 
-.agent-hero-actions {
+.agent-hero-status {
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -615,53 +673,262 @@ body {
   justify-content: flex-end;
 }
 
-.agent-metric-band {
+.agent-hero-foot {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 18px;
+}
+
+.agent-hero-foot span {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.agent-hero-foot strong {
+  font-size: 1.3rem;
+}
+
+.hitl-console {
+  gap: 20px;
+}
+
+.hitl-queue {
+  display: grid;
+  gap: 14px;
+}
+
+.hitl-item {
+  background: var(--surface-alt);
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  display: grid;
   gap: 16px;
 }
 
-.agent-metric-band article {
-  background: var(--surface);
+.hitl-item header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.hitl-item strong {
+  display: block;
+  font-size: 1.05rem;
+}
+
+.hitl-meta {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.hitl-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.hitl-note {
+  display: grid;
+  gap: 10px;
+}
+
+.hitl-note textarea {
+  resize: vertical;
+  border: 1px solid var(--border-soft);
   border-radius: var(--radius-md);
-  border: 1px solid rgba(37, 99, 235, 0.12);
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+.hitl-note-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.char-count {
+  font-size: 0.8rem;
+}
+
+.performance-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.performance-metric-grid article {
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(37, 99, 235, 0.14);
   padding: 16px;
   display: grid;
   gap: 6px;
 }
 
-.agent-metric-band span {
+.performance-metric-grid span {
   font-size: 0.85rem;
   color: var(--text-muted);
 }
 
-.agent-metric-band strong {
-  font-size: 1.3rem;
+.performance-metric-grid small {
+  font-size: 0.75rem;
 }
 
-.agent-page-grid {
+.error-breakdown {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 20px;
+  gap: 12px;
 }
 
-.agent-core {
+.error-row {
   display: grid;
-  gap: 16px;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 3fr) auto;
+  gap: 12px;
+  align-items: center;
 }
 
-.agent-side {
+.error-label {
   display: grid;
-  gap: 16px;
+  gap: 4px;
 }
 
-.checklist {
+.error-bar-track {
+  width: 100%;
+  height: 8px;
+  background: rgba(37, 99, 235, 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.error-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.8), rgba(59, 130, 246, 0.9));
+}
+
+.error-count {
+  font-weight: 600;
+}
+
+.incident-item {
+  display: grid;
+  gap: 4px;
+}
+
+.incident-item strong {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.evaluation-notes {
+  display: grid;
+  gap: 10px;
+}
+
+.evaluation-notes h4 {
+  margin: 0;
+}
+
+.note-list {
   margin: 0;
   padding-left: 20px;
   display: grid;
   gap: 8px;
   color: var(--text-secondary);
   font-size: 0.9rem;
+}
+
+.insight-actions {
+  display: grid;
+  gap: 16px;
+}
+
+.insight-action {
+  display: grid;
+  gap: 10px;
+  background: var(--surface-alt);
+  border: 1px solid rgba(37, 99, 235, 0.14);
+  border-radius: var(--radius-md);
+  padding: 16px;
+}
+
+.insight-action header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.insight-action footer {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.insight-action button {
+  justify-self: flex-start;
+}
+
+.insight-opportunities .badge-grid {
+  margin-top: 10px;
+}
+
+.playbook-card,
+.activity-card,
+.guardrail-card,
+.dependencies-card {
+  gap: 12px;
+}
+
+.agent-missing {
+  max-width: 520px;
+  text-align: center;
+  margin: 60px auto;
+  gap: 16px;
+}
+
+@media (max-width: 1100px) {
+  .agent-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-hero-status {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .agent-topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .agent-main {
+    padding: 24px;
+  }
+
+  .hero-buttons {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .hitl-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .insight-action footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .queue-layout {
@@ -867,7 +1134,7 @@ body {
     padding: 24px;
   }
 
-  .agent-page-grid {
+  .agent-detail-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,37 @@
+export function statusToColor(status) {
+  switch (status) {
+    case "active":
+    case "running":
+    case "completed":
+    case "resolved":
+    case "green":
+      return "green";
+    case "paused":
+    case "canary":
+    case "design":
+    case "investigating":
+    case "pending":
+    case "orange":
+      return "orange";
+    case "failed":
+    case "escalated":
+    case "red":
+    case "critical":
+      return "red";
+    default:
+      return "orange";
+  }
+}
+
+export function guardrailCopy(status) {
+  switch (status) {
+    case "green":
+      return "Operating within expected thresholds.";
+    case "orange":
+      return "Degradation detected. Review evaluation notebook.";
+    case "red":
+      return "Policy violation. HITL approval required before restart.";
+    default:
+      return "Monitoring.";
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared data module and standalone agent detail page with human-in-the-loop workflows, performance analytics, and actionable insights
- update inventory navigation to open dedicated agent views and refresh the app branding to “Global AI Agent Command Center”
- extend styling to support the new agent layout, queue interactions, and insight cards

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d68e05e0d8832bb8ffddcdd38e98a1