### PR TITLE
Add automated and assisted agent catalog tables

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import {
   copy,
   agents,
+  agentCatalog,
   actionQueue,
   insights,
   recommendations,
@@ -162,6 +163,9 @@ function renderModule() {
 }
 
 function renderInventoryModule(root) {
+  const catalogSection = buildAgentCatalogSection();
+  root.appendChild(catalogSection);
+
   const filteredAgents = agents.filter((agent) => {
     const statusMatch =
       state.filters.status === "all" || agent.status === state.filters.status;
@@ -188,6 +192,79 @@ function renderInventoryModule(root) {
   }
 
   root.appendChild(overview);
+}
+
+function buildAgentCatalogSection() {
+  const section = document.createElement("section");
+  section.className = "agent-catalog";
+
+  const heading = document.createElement("header");
+  heading.className = "catalog-header";
+  heading.innerHTML = `
+    <h3>Agent Catalog</h3>
+    <p class="muted">A quick reference for automated workflows and assisted copilots available across the enterprise.</p>
+  `;
+  section.appendChild(heading);
+
+  const catalogGroups = [
+    {
+      title: "Automated Agentic AI Workflows",
+      description: "Hands-off automations operating within guardrails.",
+      entries: agentCatalog.automated,
+    },
+    {
+      title: "Assisted Agentic AI (Copilot / Human-in-the-Loop)",
+      description: "Embedded copilots that support teams with insights and recommendations.",
+      entries: agentCatalog.assisted,
+    },
+  ];
+
+  catalogGroups.forEach((group) => {
+    const groupSection = document.createElement("section");
+    groupSection.className = "catalog-group";
+
+    const groupHeader = document.createElement("header");
+    groupHeader.innerHTML = `
+      <h4>${group.title}</h4>
+      <p class="muted">${group.description}</p>
+    `;
+    groupSection.appendChild(groupHeader);
+
+    const tableWrapper = document.createElement("div");
+    tableWrapper.className = "catalog-table-wrapper";
+
+    const table = document.createElement("table");
+    table.className = "catalog-table";
+
+    table.innerHTML = `
+      <thead>
+        <tr>
+          <th scope="col">Agent Name</th>
+          <th scope="col">Type</th>
+          <th scope="col">Key Properties</th>
+        </tr>
+      </thead>
+    `;
+
+    const tbody = document.createElement("tbody");
+
+    group.entries.forEach((entry) => {
+      const row = document.createElement("tr");
+      row.innerHTML = `
+        <th scope="row">${entry.name}</th>
+        <td data-label="Type">${entry.type}</td>
+        <td data-label="Key Properties">${entry.properties}</td>
+      `;
+      tbody.appendChild(row);
+    });
+
+    table.appendChild(tbody);
+    tableWrapper.appendChild(table);
+    groupSection.appendChild(tableWrapper);
+    section.appendChild(groupSection);
+  });
+
+  return section;
 }
 
 function buildInventoryHeader(agentCount) {

--- a/data.js
+++ b/data.js
@@ -21,6 +21,115 @@ export const copy = {
   },
 };
 
+export const agentCatalog = {
+  automated: [
+    {
+      name: "Dynamic Menu Optimization",
+      type: "Food & Consumer Apps",
+      properties:
+        "Analyzes consumption patterns, dietary needs, waste levels, and supplier availability to update menus daily across sites.",
+    },
+    {
+      name: "Personalized Promotions",
+      type: "Food & Consumer Apps",
+      properties:
+        "Tailors offers to user segments such as students, employees, and patients, pushing them through Everyday/So’Eze to drive adoption and revenue lift.",
+    },
+    {
+      name: "Order Routing & Capacity Management",
+      type: "Food & Consumer Apps",
+      properties:
+        "Balances demand across kitchens, kiosks, and delivery partners while adjusting prep schedules to minimize wait times and food waste.",
+    },
+    {
+      name: "Predictive Maintenance",
+      type: "Facility Management",
+      properties:
+        "Monitors IoT sensor data, predicts equipment failures, and automatically generates work orders in Service Cloud (Keystone).",
+    },
+    {
+      name: "Energy Optimization",
+      type: "Facility Management",
+      properties:
+        "Dynamically adjusts HVAC, lighting, and cleaning schedules based on occupancy and weather to drive sustainability KPIs.",
+    },
+    {
+      name: "Compliance Automation",
+      type: "Facility Management",
+      properties:
+        "Monitors cleaning and safety service data to ensure SLA compliance automatically, escalating only exceptions.",
+    },
+    {
+      name: "Shift Scheduling",
+      type: "Workforce & Ops",
+      properties:
+        "Forecasts demand such as lunch peaks and events, auto-generates optimized rosters, and syncs schedules with HR systems.",
+    },
+    {
+      name: "Inventory & Procurement",
+      type: "Workforce & Ops",
+      properties:
+        "Tracks stock levels, places restock orders, and negotiates prices dynamically across suppliers.",
+    },
+    {
+      name: "Contract Bidding Support",
+      type: "Workforce & Ops",
+      properties:
+        "Ingests bid requirements and auto-drafts Sodexo responses with historical benchmarks and compliance checks.",
+    },
+  ],
+  assisted: [
+    {
+      name: "Operations Copilot",
+      type: "Onsite Staff & Managers",
+      properties:
+        "ServiceNow/Jira-style console where managers explore performance drivers, surface correlations, and get recommended actions.",
+    },
+    {
+      name: "Menu & Nutrition Copilot",
+      type: "Onsite Staff & Managers",
+      properties:
+        "Helps chefs adapt recipes instantly for allergies and dietary needs while checking costs and supplier availability.",
+    },
+    {
+      name: "Contract Copilot",
+      type: "Onsite Staff & Managers",
+      properties:
+        "Assists sales teams with client-facing proposals by pulling case studies, KPIs, and regulatory requirements.",
+    },
+    {
+      name: "Maintenance Copilot",
+      type: "Facility Teams",
+      properties:
+        "Guides frontline staff through repairs via AR glasses or mobile apps and auto-updates maintenance logs.",
+    },
+    {
+      name: "Cleaning & Safety Copilot",
+      type: "Facility Teams",
+      properties:
+        "Provides supervisors with instant compliance risk maps and recommended actions when issues emerge.",
+    },
+    {
+      name: "Adoption & ROI Insights",
+      type: "Executives & Digital Leaders",
+      properties:
+        "Surfaces digital solution adoption, revenue impact, and retention trends across regions for platforms like Everyday, So’Eze, and Wando.",
+    },
+    {
+      name: "Strategic Planning Copilot",
+      type: "Executives & Digital Leaders",
+      properties:
+        "Combines financials, adoption, and market data to simulate scenarios such as expansion of So’Eze to additional universities.",
+    },
+    {
+      name: "Client Portal Copilot",
+      type: "Clients",
+      properties:
+        "Helps B2B clients monitor site performance, user satisfaction, sustainability impact, and costs through natural-language queries.",
+    },
+  ],
+};
+
 export const agents = [
   {
     id: "AIOPS-017",

--- a/styles.css
+++ b/styles.css
@@ -240,6 +240,11 @@ body {
   gap: 24px;
 }
 
+.catalog-group {
+  display: grid;
+  gap: 12px;
+}
+
 .catalog-header h3 {
   margin: 0;
   font-size: 1.3rem;
@@ -277,7 +282,8 @@ body {
   border-radius: var(--radius-md);
   border: 1px solid rgba(37, 99, 235, 0.12);
   background: var(--surface-alt);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .catalog-table {


### PR DESCRIPTION
## Summary
- add structured catalog data for automated agent workflows and assisted copilots
- render grouped catalog tables on the home page inventory module
- adjust catalog styling for readability and responsive scrolling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d95173567c832b8bc8e1685890ae63