### PR TITLE
Limit workflow lane tiles and standardize layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -739,6 +739,10 @@ td .workflow-cell {
   border-color: rgba(37, 99, 235, 0.3);
 }
 
+.workflow-tile {
+  min-height: 240px;
+}
+
 .agent-tile header {
   display: flex;
   justify-content: space-between;
@@ -757,6 +761,23 @@ td .workflow-cell {
   font-size: 0.85rem;
 }
 
+.workflow-tile h5 {
+  font-size: 0.95rem;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.workflow-tile p {
+  font-size: 0.75rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .tile-metrics {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -770,6 +791,7 @@ td .workflow-cell {
   border: 1px solid rgba(37, 99, 235, 0.12);
   display: grid;
   gap: 4px;
+  min-height: 68px;
 }
 
 .tile-metrics span {
@@ -778,7 +800,10 @@ td .workflow-cell {
 }
 
 .tile-metrics strong {
-  font-size: 1.05rem;
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .agent-tile footer {
@@ -786,6 +811,54 @@ td .workflow-cell {
   justify-content: space-between;
   align-items: center;
   gap: 12px;
+}
+
+.workflow-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: rgba(37, 99, 235, 0.05);
+  border: 1px dashed rgba(37, 99, 235, 0.28);
+  box-shadow: none;
+  pointer-events: none;
+  cursor: default;
+}
+
+.workflow-placeholder .placeholder-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+}
+
+.workflow-placeholder .placeholder-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-500);
+}
+
+.workflow-placeholder strong {
+  font-size: 1rem;
+  color: var(--text-secondary);
+}
+
+.workflow-placeholder p {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.lane-overflow {
+  border: 1px dashed rgba(37, 99, 235, 0.28);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  text-align: center;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent-500);
+  background: rgba(37, 99, 235, 0.08);
 }
 
 .risk-chip {


### PR DESCRIPTION
## Summary
- enforce a configurable min/max card count per workflow status lane and add overflow indicators when more items exist
- add placeholder tiles so sparse lanes keep alignment and trim tile text to avoid height spikes
- adjust workflow tile styling to keep metrics compact and placeholder/overflow UI consistent

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d96fea82ec832ba8a2aaad627bcce6