### PR TITLE
Align workflow cards to column tops

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -701,6 +701,7 @@ td .workflow-cell {
   padding: 20px;
   display: grid;
   gap: 18px;
+  align-content: start;
   position: relative;
 }
 
@@ -749,6 +750,7 @@ td .workflow-cell {
 .lane-body {
   display: grid;
   gap: 14px;
+  align-content: start;
 }
 
 .lane-body.empty {
@@ -1639,6 +1641,7 @@ td .workflow-cell {
   padding: 18px;
   display: grid;
   gap: 14px;
+  align-content: start;
   box-shadow: var(--shadow);
 }
 


### PR DESCRIPTION
## Summary
- ensure inventory workflow lanes pack their cards at the top of each column
- align human-in-the-loop queue cards to the top by anchoring grid content to the start

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d97dbc035c832bb7a52dfc618a1ac6