### PR TITLE
Remove telemetry pills and workflow badge

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,13 +23,6 @@ const state = {
   },
 };
 
-const telemetry = [
-  "Ops | Supply Chain Navigator latency spike mitigated via cache warm-up.",
-  "Security | AI Gateway policy drift resolved with auto-sync.",
-  "Compliance | Generated audit evidence pack for GDPR controllers.",
-  "Product | New agent templates published for Finance close workflows.",
-];
-
 const WORKFLOW_LANES = [
   { key: "running", label: "Running", accent: "green" },
   { key: "paused", label: "Paused", accent: "orange" },
@@ -369,25 +362,10 @@ function buildInventoryHeader(workflowCount) {
   copyBlock.innerHTML = `
     <h3>Operational snapshot</h3>
     <p class="muted">Live signals from automated and assisted workflows.</p>
+    <p class="muted inventory-total-note">${workflowCount} workflows in view</p>
   `;
 
-  const pillTray = document.createElement("div");
-  pillTray.className = "inventory-pills";
-
-  telemetry.forEach((line, index) => {
-    const pill = document.createElement("span");
-    pill.className = `status-pill ${index % 3 === 0 ? "green" : index % 3 === 1 ? "orange" : "red"}`;
-    pill.textContent = line;
-    pillTray.appendChild(pill);
-  });
-
-  const total = document.createElement("span");
-  total.className = "status-pill green";
-  total.textContent = `${workflowCount} workflows in view`;
-  pillTray.appendChild(total);
-
   header.appendChild(copyBlock);
-  header.appendChild(pillTray);
   return header;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -657,10 +657,12 @@ td .workflow-cell {
   gap: 16px;
 }
 
-.inventory-pills {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
+.inventory-overview header p {
+  margin: 8px 0 0;
+}
+
+.inventory-overview header .inventory-total-note {
+  margin-top: 4px;
 }
 
 .inventory-summary {

--- a/workflow.html
+++ b/workflow.html
@@ -9,7 +9,6 @@
   <body class="agent-page-body">
     <header class="agent-topbar">
       <a class="topbar-brand" href="index.html">
-        <span class="brand-acronym">GAACC</span>
         <div class="brand-copy">
           <strong>Global AI Agent Command Center</strong>
           <span>Workflow operations &amp; orchestration</span>


### PR DESCRIPTION
## Summary
- remove the inventory telemetry pill tray and show a simple workflow count note instead
- tweak header spacing styles to suit the text-only operational snapshot header
- remove the GAACC acronym badge from the workflow detail top bar

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d97fcffdbc832ba39cae28cf79693c